### PR TITLE
Now only considers tabs in the 'vertical' div

### DIFF
--- a/lib/tab-title.js
+++ b/lib/tab-title.js
@@ -68,7 +68,7 @@ let TabTitle = {
     },
 
     setTabTitle(index, title){
-        let tab = atom.views.getView(atom.workspace).querySelectorAll('li.tab .title')[index];
+        let tab = atom.views.getView(atom.workspace).querySelectorAll('.vertical li.tab .title')[index];
 
         if(tab)
             tab.innerText = title;


### PR DESCRIPTION
This fixes an issue where tab-title would rename the tab to the left of the one being named. This is due to the tree view's title tab also being counted as a tab, but not as a pane item.

This should fix issue #2.